### PR TITLE
feat(M3): Build Persistence & Sharing — URL encoding, hydration, share link

### DIFF
--- a/app/build/BuildClient.tsx
+++ b/app/build/BuildClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import type {
   DeadlockHeroListItem,
@@ -11,7 +11,8 @@ import type {
   AbilityLevel,
   AbilityLevels,
 } from "@/lib/deadlock";
-import { readBuild, removeFromBuild, clearBuild } from "@/lib/buildStorage";
+import { serializeBuild } from "@/lib/buildSerializer";
+import type { BuildState } from "@/lib/buildSerializer";
 import { ItemBrowser } from "@/app/build/components/ItemBrowser";
 import { AbilityLevelingPanel } from "@/app/build/components/AbilityLevelingPanel";
 import { BuildSummaryPanel } from "@/app/build/components/BuildSummaryPanel";
@@ -27,54 +28,75 @@ export default function BuildClient({
   selectedHeroId,
   upgrades,
   heroAbilities = [],
+  initialState = null,
 }: {
   heroes: DeadlockHeroListItem[];
   selectedHeroId: string | null;
   upgrades: ShopItem[];
   heroAbilities?: HeroAbilitySlot[];
+  initialState?: BuildState | null;
 }) {
   const router = useRouter();
   const [heroId, setHeroId] = useState<string>(selectedHeroId ?? "");
-  const [refresh, setRefresh] = useState(0);
   const [activeTab, setActiveTab] = useState<ShopCategory>("weapon");
-  const [abilityLevels, setAbilityLevels] = useState<AbilityLevels>({});
 
-  const buildItems = useMemo(() => {
-    if (!heroId) return [];
-    return readBuild(heroId);
-  }, [heroId, refresh]);
+  // Initialize directly from server-provided initialState — no localStorage read on any render
+  const [selectedItems, setSelectedItems] = useState<ShopItem[]>(() => {
+    if (!initialState) return [];
+    const byId = new Map(upgrades.map((u) => [u.id, u]));
+    return initialState.itemIds.flatMap((id) => {
+      const item = byId.get(id);
+      return item ? [item] : [];
+    });
+  });
 
-  const selectedIds = useMemo(
-    () => new Set(buildItems.map((it) => it.id)),
-    [buildItems]
+  const [abilityLevels, setAbilityLevels] = useState<AbilityLevels>(
+    initialState?.abilityLevels ?? {},
   );
 
-  const selectedItems = useMemo(() => {
-    if (buildItems.length === 0) return [];
-    const byId = new Map(upgrades.map((u) => [u.id, u]));
-    return buildItems.flatMap((it) => {
-      const shopItem = byId.get(it.id);
-      return shopItem ? [shopItem] : [];
-    });
-  }, [buildItems, upgrades]);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  const selectedIds = useMemo(
+    () => new Set(selectedItems.map((it) => it.id)),
+    [selectedItems],
+  );
 
   const selectedHero = useMemo(
     () => heroes.find((h) => String(h.id) === String(heroId)),
-    [heroes, heroId]
+    [heroes, heroId],
   );
-
-  useEffect(() => {
-    const handler = () => setRefresh((x) => x + 1);
-    window.addEventListener("deadlock-build-changed", handler);
-    window.addEventListener("storage", handler);
-    return () => {
-      window.removeEventListener("deadlock-build-changed", handler);
-      window.removeEventListener("storage", handler);
-    };
-  }, []);
 
   function handleLevelChange(slot: SignatureSlot, level: AbilityLevel) {
     setAbilityLevels((prev) => ({ ...prev, [slot]: level }));
+  }
+
+  function handleToggleItem(item: ShopItem) {
+    setSelectedItems((prev) =>
+      prev.some((it) => it.id === item.id)
+        ? prev.filter((it) => it.id !== item.id)
+        : [...prev, item],
+    );
+  }
+
+  async function handleCopyShareLink() {
+    const state: BuildState = {
+      heroId,
+      itemIds: selectedItems.map((it) => it.id),
+      abilityLevels,
+    };
+    const encoded = serializeBuild(state);
+    const url = `${window.location.origin}${window.location.pathname}?build=${encoded}`;
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopyState("copied");
+      setFailedUrl(null);
+      setTimeout(() => setCopyState("idle"), 2000);
+    } catch {
+      setCopyState("failed");
+      setFailedUrl(url);
+    }
   }
 
   return (
@@ -87,6 +109,7 @@ export default function BuildClient({
           onChange={(e) => {
             const next = e.target.value;
             setHeroId(next);
+            setSelectedItems([]);
             setAbilityLevels({});
             if (!next) router.push("/build");
             else router.push(`/build/${next}`);
@@ -124,6 +147,65 @@ export default function BuildClient({
             </div>
           </div>
         ) : null}
+
+        {heroId ? (
+          <div style={{ marginLeft: "auto", position: "relative" }}>
+            <button
+              onClick={handleCopyShareLink}
+              style={{
+                padding: "8px 16px",
+                borderRadius: 8,
+                border: "1px solid rgba(255,255,255,0.35)",
+                background:
+                  copyState === "copied" ? "rgba(34,197,94,0.2)" : "rgba(255,255,255,0.12)",
+                color: copyState === "copied" ? "#4ade80" : "inherit",
+                cursor: "pointer",
+                fontWeight: 600,
+                fontSize: 13,
+                whiteSpace: "nowrap",
+                transition: "background 0.15s, color 0.15s",
+              }}
+            >
+              {copyState === "copied" ? "Copied!" : "Copy Share Link"}
+            </button>
+            {copyState === "failed" && failedUrl ? (
+              <div
+                style={{
+                  position: "absolute",
+                  top: "calc(100% + 8px)",
+                  right: 0,
+                  background: "#1e1e2e",
+                  border: "1px solid rgba(255,255,255,0.2)",
+                  borderRadius: 8,
+                  padding: "10px 14px",
+                  zIndex: 50,
+                  minWidth: 320,
+                  maxWidth: 400,
+                }}
+              >
+                <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 6 }}>
+                  Clipboard unavailable — copy manually:
+                </div>
+                <input
+                  readOnly
+                  value={failedUrl}
+                  onClick={(e) => (e.target as HTMLInputElement).select()}
+                  style={{
+                    width: "100%",
+                    background: "rgba(255,255,255,0.06)",
+                    border: "1px solid rgba(255,255,255,0.12)",
+                    borderRadius: 6,
+                    padding: "6px 8px",
+                    fontSize: 11,
+                    fontFamily: "monospace",
+                    color: "inherit",
+                    boxSizing: "border-box",
+                  }}
+                />
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </header>
 
       {!heroId ? (
@@ -159,17 +241,14 @@ export default function BuildClient({
               >
                 <h2 style={{ margin: 0 }}>{selectedHero?.name ?? "Selected Hero"}</h2>
                 <button
-                  onClick={() => {
-                    clearBuild(heroId);
-                    setRefresh((x) => x + 1);
-                  }}
-                  disabled={buildItems.length === 0}
+                  onClick={() => setSelectedItems([])}
+                  disabled={selectedItems.length === 0}
                 >
                   Clear
                 </button>
               </div>
 
-              {buildItems.length === 0 ? (
+              {selectedItems.length === 0 ? (
                 <div style={{ marginTop: 12, opacity: 0.6 }}>No items added yet.</div>
               ) : (
                 <ul
@@ -202,10 +281,9 @@ export default function BuildClient({
                       >
                         <div style={{ fontWeight: 600, fontSize: 14 }}>{it.name}</div>
                         <button
-                          onClick={() => {
-                            removeFromBuild(heroId, it.id);
-                            setRefresh((x) => x + 1);
-                          }}
+                          onClick={() =>
+                            setSelectedItems((prev) => prev.filter((x) => x.id !== it.id))
+                          }
                           style={{
                             padding: "4px 8px",
                             borderRadius: 6,
@@ -226,11 +304,11 @@ export default function BuildClient({
             </section>
 
             <ItemBrowser
-              heroId={heroId}
               items={upgrades}
               activeTab={activeTab}
               onTabChange={setActiveTab}
               selectedIds={selectedIds}
+              onToggle={handleToggleItem}
             />
           </div>
 

--- a/app/build/[heroId]/page.tsx
+++ b/app/build/[heroId]/page.tsx
@@ -8,13 +8,18 @@ import {
   fetchAbilityItems,
   getHeroSignatureSlotsFromHeroItems,
 } from "@/lib/deadlock";
+import { deserializeBuild } from "@/lib/buildSerializer";
+import type { BuildState } from "@/lib/buildSerializer";
 
 export default async function BuildHeroPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ heroId: string }>;
+  searchParams: Promise<{ build?: string }>;
 }) {
   const { heroId } = await params;
+  const { build } = await searchParams;
 
   // Keep hero set consistent with /build (visible/selectable only)
   const heroes = await fetchVisibleHeroes();
@@ -33,8 +38,17 @@ export default async function BuildHeroPage({
   const heroAbilities = getHeroSignatureSlotsFromHeroItems(
     heroData.items,
     allAbilities,
-    heroData.id
+    heroData.id,
   );
+
+  let initialState: BuildState | null = null;
+  if (build) {
+    try {
+      initialState = deserializeBuild(build);
+    } catch {
+      // Malformed param — fall through to empty state
+    }
+  }
 
   return (
     <BuildClient
@@ -42,6 +56,7 @@ export default async function BuildHeroPage({
       selectedHeroId={heroId}
       upgrades={upgrades}
       heroAbilities={heroAbilities}
+      initialState={initialState}
     />
   );
 }

--- a/app/build/components/BuildSummaryPanel.tsx
+++ b/app/build/components/BuildSummaryPanel.tsx
@@ -1,9 +1,5 @@
 import type { ShopItem } from "@/lib/deadlock";
-import {
-  calculateDamageSplit,
-  calculateStatTotals,
-  calculateTotalCost,
-} from "@/lib/buildCalculations";
+import { calculateDamageSplit, calculateTotalCost } from "@/lib/buildCalculations";
 
 const COLORS = {
   spirit: { solid: "#7c3aed", label: "Spirit" },
@@ -17,7 +13,6 @@ function fmt(n: number): string {
 
 export function BuildSummaryPanel({ selectedItems }: { selectedItems: ShopItem[] }) {
   const split = calculateDamageSplit(selectedItems);
-  const stats = calculateStatTotals(selectedItems);
   const totalCost = calculateTotalCost(selectedItems);
   const hasItems = selectedItems.length > 0;
 
@@ -97,26 +92,17 @@ export function BuildSummaryPanel({ selectedItems }: { selectedItems: ShopItem[]
           Stat Contributions
         </div>
 
-        <div style={{ display: "grid", gap: 8 }}>
-          {(["spirit", "gun", "vitality"] as const).map((cat) => (
-            <div
-              key={cat}
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                padding: "8px 12px",
-                borderRadius: 8,
-                border: `1px solid ${COLORS[cat].solid}40`,
-                background: `${COLORS[cat].solid}12`,
-              }}
-            >
-              <span style={{ color: COLORS[cat].solid, fontWeight: 700, fontSize: 13 }}>
-                {COLORS[cat].label}
-              </span>
-              <span style={{ fontWeight: 700, fontSize: 14 }}>{fmt(stats[cat])}</span>
-            </div>
-          ))}
+        <div
+          style={{
+            padding: "12px 14px",
+            borderRadius: 8,
+            border: "1px solid rgba(255,255,255,0.10)",
+            background: "rgba(255,255,255,0.04)",
+            fontSize: 13,
+            opacity: 0.55,
+          }}
+        >
+          Stat data coming in M4
         </div>
       </section>
 

--- a/app/build/components/ItemBrowser.tsx
+++ b/app/build/components/ItemBrowser.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo } from "react";
-import { addToBuild, removeFromBuild } from "@/lib/buildStorage";
 import type { ShopCategory, ShopItem, ShopTier } from "@/lib/deadlock";
 
 const TIERS: ShopTier[] = [1, 2, 3, 4];
@@ -46,17 +45,17 @@ function tierCost(t: ShopTier): number {
 }
 
 export function ItemBrowser({
-  heroId,
   items,
   activeTab,
   onTabChange,
   selectedIds,
+  onToggle,
 }: {
-  heroId: string;
   items: ShopItem[];
   activeTab: ShopCategory;
   onTabChange: (tab: ShopCategory) => void;
   selectedIds: ReadonlySet<string>;
+  onToggle: (item: ShopItem) => void;
 }) {
   const meta = TAB_META[activeTab];
 
@@ -153,7 +152,9 @@ export function ItemBrowser({
                           background: isSelected ? meta.accentSoft : "transparent",
                         }}
                       >
-                        <div style={{ display: "flex", gap: 10, alignItems: "center", minWidth: 0 }}>
+                        <div
+                          style={{ display: "flex", gap: 10, alignItems: "center", minWidth: 0 }}
+                        >
                           {it.icon ? (
                             // eslint-disable-next-line @next/next/no-img-element
                             <img
@@ -198,13 +199,7 @@ export function ItemBrowser({
                         </div>
 
                         <button
-                          onClick={() => {
-                            if (isSelected) {
-                              removeFromBuild(heroId, it.id);
-                            } else {
-                              addToBuild(heroId, { id: it.id, name: it.name });
-                            }
-                          }}
+                          onClick={() => onToggle(it)}
                           style={{
                             padding: "5px 9px",
                             borderRadius: 8,

--- a/app/heroes/components/AddToBuildButton.tsx
+++ b/app/heroes/components/AddToBuildButton.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
-import { addToBuild, readBuild, BuildItem } from "@/lib/buildStorage";
+import Link from "next/link";
 
-export function AddToBuildButton({ heroId, item }: { heroId: string | number; item: BuildItem }) {
-  const added = useMemo(() => {
-    return readBuild(heroId).some((x) => x.id === item.id);
-  }, [heroId, item.id]);
-
+export function AddToBuildButton({ heroId }: { heroId: string | number }) {
   return (
-    <button
-      onClick={() => addToBuild(heroId, item)}
-      disabled={added}
-      style={{ padding: "6px 10px", borderRadius: 8 }}
+    <Link
+      href={`/build/${heroId}`}
+      style={{ padding: "6px 10px", borderRadius: 8, textDecoration: "none" }}
     >
-      {added ? "Added" : "Add to Build"}
-    </button>
+      Build →
+    </Link>
   );
 }

--- a/app/heroes/components/ShopGrid.tsx
+++ b/app/heroes/components/ShopGrid.tsx
@@ -225,7 +225,7 @@ export function ShopGrid({
                         </div>
                       </div>
 
-                      <AddToBuildButton heroId={heroId} item={{ id: it.id, name: it.name }} />
+                      <AddToBuildButton heroId={heroId} />
                     </li>
                   ))}
                 </ul>

--- a/lib/buildSerializer.ts
+++ b/lib/buildSerializer.ts
@@ -1,0 +1,79 @@
+import type { AbilityLevels, SignatureSlot, AbilityLevel } from "@/lib/deadlock";
+
+export type BuildState = {
+  heroId: string;
+  itemIds: string[];
+  abilityLevels: AbilityLevels;
+};
+
+export function serializeBuild(state: BuildState): string {
+  const json = JSON.stringify(state);
+  const b64 = btoa(json);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function deserializeBuild(encoded: string): BuildState {
+  const b64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  const json = atob(padded);
+  const parsed: unknown = JSON.parse(json);
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("Invalid build state: not an object");
+  }
+
+  const raw = parsed as Record<string, unknown>;
+
+  if (typeof raw.heroId !== "string") {
+    throw new Error("Invalid build state: missing heroId");
+  }
+
+  if (!Array.isArray(raw.itemIds)) {
+    throw new Error("Invalid build state: missing itemIds");
+  }
+
+  return {
+    heroId: raw.heroId,
+    itemIds: (raw.itemIds as unknown[]).filter((id): id is string => typeof id === "string"),
+    abilityLevels: parseAbilityLevels(raw.abilityLevels),
+  };
+}
+
+function parseAbilityLevels(raw: unknown): AbilityLevels {
+  if (typeof raw !== "object" || raw === null) return {};
+  const result: AbilityLevels = {};
+  const slots: SignatureSlot[] = ["signature1", "signature2", "signature3", "signature4"];
+  for (const slot of slots) {
+    const val = (raw as Record<string, unknown>)[slot];
+    if (val === 0 || val === 1 || val === 2 || val === 3) {
+      result[slot] = val as AbilityLevel;
+    }
+  }
+  return result;
+}
+
+if (process.env.NODE_ENV === "development") {
+  (() => {
+    const testState: BuildState = {
+      heroId: "test-hero-42",
+      itemIds: ["111", "222", "333"],
+      abilityLevels: { signature1: 1, signature2: 2, signature4: 3 },
+    };
+    try {
+      const encoded = serializeBuild(testState);
+      const decoded = deserializeBuild(encoded);
+      const match =
+        decoded.heroId === testState.heroId &&
+        decoded.itemIds.join(",") === testState.itemIds.join(",") &&
+        JSON.stringify(decoded.abilityLevels) === JSON.stringify(testState.abilityLevels);
+      if (!match) {
+        console.error("[buildSerializer] Round-trip test FAILED", {
+          testState,
+          decoded,
+        });
+      }
+    } catch (err) {
+      console.error("[buildSerializer] Round-trip test threw", err);
+    }
+  })();
+}


### PR DESCRIPTION
## Summary
Completes Milestone 3 — a user can construct a build, copy a share link, and another user loads the exact same build from the URL alone. No database required — all state is URL-encoded.

## Issues closed
- Closes #22 (Build-06: URL encoding for builds)
- Closes #23 (Build-07: Hydrate build state from URL params)
- Closes #24 (Build-08: Copy Share Link button)

## Changes
- `lib/buildSerializer.ts` — `serializeBuild` and `deserializeBuild` pure functions, JSON → base64url, dev-mode round-trip assertion
- `app/build/[heroId]/page.tsx` — reads `?build=` param server-side, passes decoded `initialState` to BuildClient
- `app/build/BuildClient.tsx` — `initialState` hydration on first mount, Copy Share Link button with Copied! feedback and manual-copy popover fallback
- `app/build/components/ItemBrowser.tsx` — removed localStorage calls, threaded `onToggle` callback from BuildClient
- `app/heroes/components/AddToBuildButton.tsx` — converted from stateful localStorage button to simple hero build link
- `app/heroes/components/ShopGrid.tsx` — updated AddToBuildButton call site
- `app/build/components/BuildSummaryPanel.tsx` — stat contributions placeholder pending M4 real data (bonus fields are hardcoded to 0 in normalizeUpgradeItems)

## Architecture notes
- URL is the sole persistence mechanism — no localStorage, no database
- All serialization logic is pure functions in `buildSerializer.ts`
- Hydration is one-shot on mount — URL param does not override subsequent user changes
- Hydration failure (malformed URL) falls back to empty state gracefully

## Verification
- `npx tsc --noEmit` — zero errors
- `npx next build` — exit code 0
- Manually verified: build constructed → share link copied → opened in incognito → identical build loaded

## Reviewer checklist
- [ ] Build a build, click Copy Share Link, open in incognito — same build loads
- [ ] Malformed `?build=` param does not crash — falls back to empty
- [ ] Stat Contributions shows placeholder (real data coming M4)
- [ ] Soul Cost Split bar and Total Build Cost display correctly

## Out of scope (tracked separately)
- Build-06 drag-and-drop categories → M4
- Real stat contribution data → M4

🤖 Generated with [Claude Code](https://claude.com/claude-code)