### PR TITLE
feat(M5a): Build Planner Game Plan Structure

### DIFF
--- a/app/build/BuildClient.tsx
+++ b/app/build/BuildClient.tsx
@@ -13,14 +13,16 @@ import type {
 } from "@/lib/deadlock";
 import { serializeBuild } from "@/lib/buildSerializer";
 import type { BuildState } from "@/lib/buildSerializer";
+import { getItemAssignments } from "@/lib/buildSerializer";
 import { ItemBrowser } from "@/app/build/components/ItemBrowser";
 import { AbilityLevelingPanel } from "@/app/build/components/AbilityLevelingPanel";
 import { BuildSummaryPanel } from "@/app/build/components/BuildSummaryPanel";
 import { SuggestedItemsPanel } from "@/app/build/components/SuggestedItemsPanel";
 import { CategoryManager } from "@/app/build/components/CategoryManager";
-import type { Item, BuildCategory } from "@/lib/items";
+import type { Item, BuildCategory, ItemAssignment, ItemDestination, ItemPhase } from "@/lib/items";
 import type { BuildGoal } from "@/lib/scoring/goalWeights";
 import { getConsumedComponents, resolveAddItem } from "@/lib/buildUtils";
+import { arrayMove } from "@dnd-kit/sortable";
 
 const GOALS: { value: BuildGoal; label: string }[] = [
   { value: "burst", label: "Burst" },
@@ -29,6 +31,20 @@ const GOALS: { value: BuildGoal; label: string }[] = [
   { value: "sustain", label: "Sustain" },
   { value: "mobility", label: "Mobility" },
 ];
+
+type AssignmentData = {
+  phase: ItemPhase | null;
+  active: boolean;
+  sellPriority: boolean;
+  optional: boolean;
+};
+
+const DEFAULT_ASSIGNMENT: AssignmentData = {
+  phase: null,
+  active: false,
+  sellPriority: false,
+  optional: false,
+};
 
 function cleanCategories(
   categories: BuildCategory[],
@@ -78,6 +94,24 @@ export default function BuildClient({
     initialState?.categories ?? [],
   );
 
+  // Per-item assignment state — keyed by item ID
+  const [assignmentMap, setAssignmentMap] = useState<Map<string, AssignmentData>>(() => {
+    if (!initialState) return new Map();
+    const assignments = getItemAssignments(initialState);
+    return new Map(
+      assignments.map((a) => [
+        a.itemId,
+        {
+          phase: a.phase,
+          active: a.active,
+          sellPriority: a.sellPriority,
+          optional: a.optional,
+        },
+      ]),
+    );
+  });
+
+  const [activeError, setActiveError] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
@@ -91,6 +125,27 @@ export default function BuildClient({
   const selectedHero = useMemo(
     () => heroes.find((h) => String(h.id) === String(heroId)),
     [heroes, heroId],
+  );
+
+  const activeCount = useMemo(
+    () => Array.from(assignmentMap.values()).filter((a) => a.active).length,
+    [assignmentMap],
+  );
+
+  // Derive ItemAssignment[] for components
+  const itemAssignments = useMemo<ItemAssignment[]>(
+    () =>
+      buildItems.map((it) => {
+        const a = assignmentMap.get(it.id) ?? DEFAULT_ASSIGNMENT;
+        return {
+          itemId: it.id,
+          phase: a.phase,
+          active: a.active,
+          sellPriority: a.sellPriority,
+          optional: a.optional,
+        };
+      }),
+    [buildItems, assignmentMap],
   );
 
   function handleLevelChange(slot: SignatureSlot, level: AbilityLevel) {
@@ -117,6 +172,100 @@ export default function BuildClient({
 
   function handleRemoveItem(itemId: string) {
     setBuildItems((prev) => prev.filter((it) => it.id !== itemId));
+    setAssignmentMap((prev) => {
+      const next = new Map(prev);
+      next.delete(itemId);
+      return next;
+    });
+    setCategories((prev) =>
+      prev.map((c) => ({ ...c, itemIds: c.itemIds.filter((id) => id !== itemId) })),
+    );
+  }
+
+  function handleItemMove(itemId: string, dest: ItemDestination) {
+    setAssignmentMap((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(itemId) ?? { ...DEFAULT_ASSIGNMENT };
+      switch (dest.type) {
+        case "phase":
+          // Preserve sell/optional flags — they are independent of location
+          next.set(itemId, { ...cur, phase: dest.phase });
+          break;
+        case "category":
+        case "uncategorized":
+          // Preserve sell/optional flags — they are independent of location
+          next.set(itemId, { ...cur, phase: null });
+          break;
+      }
+      return next;
+    });
+
+    if (dest.type === "category") {
+      setCategories((prev) =>
+        prev.map((c) => {
+          if (c.id === dest.categoryId) {
+            return {
+              ...c,
+              itemIds: c.itemIds.includes(itemId) ? c.itemIds : [...c.itemIds, itemId],
+            };
+          }
+          return { ...c, itemIds: c.itemIds.filter((id) => id !== itemId) };
+        }),
+      );
+    } else {
+      setCategories((prev) =>
+        prev.map((c) => ({ ...c, itemIds: c.itemIds.filter((id) => id !== itemId) })),
+      );
+    }
+  }
+
+  function handleToggleSellPriority(itemId: string) {
+    setAssignmentMap((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(itemId) ?? { ...DEFAULT_ASSIGNMENT };
+      next.set(itemId, { ...cur, sellPriority: !cur.sellPriority });
+      return next;
+    });
+  }
+
+  function handleToggleOptional(itemId: string) {
+    setAssignmentMap((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(itemId) ?? { ...DEFAULT_ASSIGNMENT };
+      const newOptional = !cur.optional;
+      next.set(itemId, { ...cur, optional: newOptional, active: newOptional ? false : cur.active });
+      return next;
+    });
+  }
+
+  function handleReorderBuildItems(itemId: string, overId: string) {
+    setBuildItems((prev) => {
+      const from = prev.findIndex((it) => it.id === itemId);
+      const to = prev.findIndex((it) => it.id === overId);
+      if (from === -1 || to === -1) return prev;
+      return arrayMove(prev, from, to);
+    });
+  }
+
+  function handleToggleActive(itemId: string) {
+    const cur = assignmentMap.get(itemId) ?? DEFAULT_ASSIGNMENT;
+    if (cur.optional) return;
+
+    const isCurrentlyActive = cur.active;
+    if (!isCurrentlyActive) {
+      if (activeCount >= 12) {
+        setActiveError("Active build full — remove an active item first");
+        setTimeout(() => setActiveError(null), 3000);
+        return;
+      }
+    }
+
+    setAssignmentMap((prev) => {
+      const next = new Map(prev);
+      const a = next.get(itemId) ?? { ...DEFAULT_ASSIGNMENT };
+      next.set(itemId, { ...a, active: !isCurrentlyActive });
+      return next;
+    });
   }
 
   async function handleCopyShareLink() {
@@ -125,6 +274,10 @@ export default function BuildClient({
       itemIds: buildItems.map((it) => it.id),
       abilityLevels,
       categories: cleanedCategories,
+      phases: buildItems.map((it) => assignmentMap.get(it.id)?.phase ?? null),
+      active: buildItems.map((it) => assignmentMap.get(it.id)?.active ?? false),
+      sell: buildItems.map((it) => assignmentMap.get(it.id)?.sellPriority ?? false),
+      optional: buildItems.map((it) => assignmentMap.get(it.id)?.optional ?? false),
     };
     const encoded = serializeBuild(state);
     const url = `${window.location.origin}${window.location.pathname}?build=${encoded}`;
@@ -153,6 +306,7 @@ export default function BuildClient({
             setBuildItems([]);
             setAbilityLevels({});
             setCategories([]);
+            setAssignmentMap(new Map());
             if (!next) router.push("/build");
             else router.push(`/build/${next}`);
           }}
@@ -202,7 +356,8 @@ export default function BuildClient({
                   padding: "5px 12px",
                   borderRadius: 999,
                   border: `1px solid ${selectedGoal === value ? "rgba(255,255,255,0.5)" : "rgba(255,255,255,0.2)"}`,
-                  background: selectedGoal === value ? "rgba(255,255,255,0.15)" : "transparent",
+                  background:
+                    selectedGoal === value ? "rgba(255,255,255,0.15)" : "transparent",
                   color: "inherit",
                   fontWeight: selectedGoal === value ? 700 : 400,
                   cursor: "pointer",
@@ -217,12 +372,23 @@ export default function BuildClient({
         ) : null}
 
         {heroId ? (
-          <div style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center", position: "relative" }}>
-            <span style={{ fontSize: 12, opacity: 0.5 }}>{buildItems.length} / 12 slots</span>
+          <div
+            style={{
+              marginLeft: "auto",
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              position: "relative",
+            }}
+          >
+            <span style={{ fontSize: 12, opacity: 0.5 }}>
+              {activeCount}/12 active · {buildItems.length} items
+            </span>
             <button
               onClick={() => {
                 setBuildItems([]);
                 setCategories([]);
+                setAssignmentMap(new Map());
               }}
               disabled={buildItems.length === 0}
               style={{
@@ -322,8 +488,14 @@ export default function BuildClient({
             <CategoryManager
               categories={cleanedCategories}
               buildItems={buildItems}
+              itemAssignments={itemAssignments}
               onCategoriesChange={setCategories}
+              onItemMove={handleItemMove}
               onRemoveBuildItem={handleRemoveItem}
+              onToggleActive={handleToggleActive}
+              onToggleSellPriority={handleToggleSellPriority}
+              onToggleOptional={handleToggleOptional}
+              onReorderBuildItems={handleReorderBuildItems}
               consumedComponents={consumedComponents}
             />
 
@@ -333,7 +505,7 @@ export default function BuildClient({
               onTabChange={setActiveTab}
               selectedIds={selectedIds}
               onToggle={handleToggleItem}
-              slotsFull={buildItems.length >= 12}
+              slotsFull={false}
             />
           </div>
 
@@ -345,9 +517,14 @@ export default function BuildClient({
               selectedGoal={selectedGoal}
               onAdd={handleAddSuggestedItem}
               consumedComponents={consumedComponents}
-              slotsFull={buildItems.length >= 12}
+              slotsFull={false}
             />
-            <BuildSummaryPanel selectedItems={buildItems} />
+            <BuildSummaryPanel
+              selectedItems={buildItems}
+              assignments={itemAssignments}
+              activeError={activeError}
+              onToggleActive={handleToggleActive}
+            />
           </div>
         </div>
       )}

--- a/app/build/components/ActiveItemsGrid.tsx
+++ b/app/build/components/ActiveItemsGrid.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import type { Item, ItemAssignment } from "@/lib/items";
+import { getActiveItems } from "@/lib/buildCalculations";
+import { calculateDamageSplit, calculateTotalCost } from "@/lib/buildCalculations";
+
+const COLORS = {
+  spirit: { solid: "#7c3aed", label: "Spirit" },
+  gun: { solid: "#ea580c", label: "Gun" },
+  vitality: { solid: "#16a34a", label: "Vitality" },
+} as const;
+
+const SLOT_COUNT = 12;
+
+function fmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+export function ActiveItemsGrid({
+  allItems,
+  assignments,
+  activeError,
+  onToggleActive,
+}: {
+  allItems: Item[];
+  assignments: ItemAssignment[];
+  activeError: string | null;
+  onToggleActive: (itemId: string) => void;
+}) {
+  const activeItems = getActiveItems(allItems, assignments);
+  const split = calculateDamageSplit(activeItems);
+  const totalCost = calculateTotalCost(activeItems);
+  const count = activeItems.length;
+
+  const slots: Array<Item | null> = [
+    ...activeItems,
+    ...Array<null>(Math.max(0, SLOT_COUNT - activeItems.length)).fill(null),
+  ];
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            opacity: 0.6,
+            textTransform: "uppercase",
+            letterSpacing: 0.8,
+          }}
+        >
+          Active Build
+        </div>
+        <span
+          style={{
+            fontSize: 12,
+            opacity: 0.55,
+            fontWeight: 600,
+            color: count >= SLOT_COUNT ? "#f87171" : "inherit",
+          }}
+        >
+          {count} / {SLOT_COUNT} active
+        </span>
+      </div>
+
+      {activeError ? (
+        <div
+          style={{
+            fontSize: 12,
+            color: "#f87171",
+            background: "rgba(239,68,68,0.1)",
+            border: "1px solid rgba(239,68,68,0.3)",
+            borderRadius: 6,
+            padding: "6px 10px",
+          }}
+        >
+          {activeError}
+        </div>
+      ) : null}
+
+      {/* 4×3 slot grid */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 6,
+        }}
+      >
+        {slots.map((item, i) =>
+          item ? (
+            <button
+              key={item.id}
+              onClick={() => onToggleActive(item.id)}
+              title="Click to remove from active build"
+              style={{
+                position: "relative",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 4,
+                padding: "6px 4px",
+                borderRadius: 8,
+                border: "1px solid rgba(255,255,255,0.18)",
+                background: "rgba(255,255,255,0.07)",
+                cursor: "pointer",
+                color: "inherit",
+                minHeight: 64,
+                overflow: "hidden",
+              }}
+            >
+              <span
+                style={{
+                  position: "absolute",
+                  top: 2,
+                  right: 4,
+                  fontSize: 9,
+                  lineHeight: 1,
+                  color: "#facc15",
+                  pointerEvents: "none",
+                }}
+              >
+                ★
+              </span>
+              {item.icon ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={item.icon}
+                  alt={item.name}
+                  width={28}
+                  height={28}
+                  style={{ borderRadius: 6, flexShrink: 0 }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: 6,
+                    background: "rgba(255,255,255,0.1)",
+                  }}
+                />
+              )}
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  lineHeight: 1.2,
+                  textAlign: "center",
+                  overflow: "hidden",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  wordBreak: "break-word",
+                }}
+              >
+                {item.name}
+              </span>
+            </button>
+          ) : (
+            <div
+              key={`empty-${i}`}
+              style={{
+                minHeight: 64,
+                borderRadius: 8,
+                border: "1px dashed rgba(255,255,255,0.12)",
+                background: "rgba(255,255,255,0.02)",
+              }}
+            />
+          ),
+        )}
+      </div>
+
+      {/* Soul cost split bar */}
+      {count > 0 ? (
+        <>
+          <div
+            style={{
+              height: 6,
+              borderRadius: 4,
+              overflow: "hidden",
+              background: "rgba(255,255,255,0.08)",
+              display: "flex",
+            }}
+          >
+            {split.gun > 0 && (
+              <div
+                style={{ flex: split.gun, background: COLORS.gun.solid }}
+                title={`Gun: ${fmt(split.gun)}`}
+              />
+            )}
+            {split.vitality > 0 && (
+              <div
+                style={{ flex: split.vitality, background: COLORS.vitality.solid }}
+                title={`Vitality: ${fmt(split.vitality)}`}
+              />
+            )}
+            {split.spirit > 0 && (
+              <div
+                style={{ flex: split.spirit, background: COLORS.spirit.solid }}
+                title={`Spirit: ${fmt(split.spirit)}`}
+              />
+            )}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontSize: 11,
+              opacity: 0.7,
+            }}
+          >
+            <span>◈ {fmt(totalCost)} souls</span>
+            <span style={{ display: "flex", gap: 8 }}>
+              {split.gun > 0 && (
+                <span style={{ color: COLORS.gun.solid }}>{fmt(split.gun)}</span>
+              )}
+              {split.vitality > 0 && (
+                <span style={{ color: COLORS.vitality.solid }}>{fmt(split.vitality)}</span>
+              )}
+              {split.spirit > 0 && (
+                <span style={{ color: COLORS.spirit.solid }}>{fmt(split.spirit)}</span>
+              )}
+            </span>
+          </div>
+        </>
+      ) : (
+        <div style={{ fontSize: 12, opacity: 0.4, fontStyle: "italic" }}>
+          Use ★ buttons in the build list to mark items as active
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/build/components/BuildSummaryPanel.tsx
+++ b/app/build/components/BuildSummaryPanel.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import type { Item } from "@/lib/items";
+import { useState } from "react";
+import type { Item, ItemAssignment } from "@/lib/items";
 import type { CategoryBonus } from "@/lib/categoryBonuses";
 import { isApproachingSignificantBonus } from "@/lib/categoryBonuses";
 import { detectAntiSynergies } from "@/lib/scoring/antiSynergy";
-import { calculateDamageSplit, calculateTotalCost } from "@/lib/buildCalculations";
+import {
+  calculateDamageSplit,
+  calculateTotalCost,
+  getActiveItems,
+  getPlanItems,
+} from "@/lib/buildCalculations";
+import { ActiveItemsGrid } from "./ActiveItemsGrid";
 
 const COLORS = {
   spirit: { solid: "#7c3aed", label: "Spirit" },
@@ -96,25 +103,97 @@ const BONUS_META: Record<
 export function BuildSummaryPanel({
   selectedItems,
   suggestedBuildItems = [],
+  assignments = [],
+  activeError = null,
+  onToggleActive,
 }: {
   selectedItems: Item[];
   suggestedBuildItems?: Item[];
+  assignments?: ItemAssignment[];
+  activeError?: string | null;
+  onToggleActive?: (itemId: string) => void;
 }) {
+  const [mode, setMode] = useState<"active" | "plan">("plan");
+
   const allBuildItems = [...selectedItems, ...suggestedBuildItems];
-  const split = calculateDamageSplit(allBuildItems);
-  const totalCost = calculateTotalCost(allBuildItems);
-  const hasItems = allBuildItems.length > 0;
+
+  const displayItems =
+    mode === "active"
+      ? getActiveItems(allBuildItems, assignments)
+      : getPlanItems(allBuildItems, assignments);
+
+  const split = calculateDamageSplit(displayItems);
+  const totalCost = calculateTotalCost(displayItems);
+  const hasItems = displayItems.length > 0;
 
   const antiSynergies = detectAntiSynergies(allBuildItems);
 
-  const bonusRows: { key: CategoryKey; souls: number; bonus: CategoryBonus | null; toNextTier: number | null }[] = [
+  const bonusRows: {
+    key: CategoryKey;
+    souls: number;
+    bonus: CategoryBonus | null;
+    toNextTier: number | null;
+  }[] = [
     { key: "gun", souls: split.gun, bonus: split.gunBonus, toNextTier: split.gunToNextTier },
-    { key: "vitality", souls: split.vitality, bonus: split.vitalityBonus, toNextTier: split.vitalityToNextTier },
-    { key: "spirit", souls: split.spirit, bonus: split.spiritBonus, toNextTier: split.spiritToNextTier },
+    {
+      key: "vitality",
+      souls: split.vitality,
+      bonus: split.vitalityBonus,
+      toNextTier: split.vitalityToNextTier,
+    },
+    {
+      key: "spirit",
+      souls: split.spirit,
+      bonus: split.spiritBonus,
+      toNextTier: split.spiritToNextTier,
+    },
   ];
 
   return (
     <aside style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      {/* Active Items Grid */}
+      {onToggleActive ? (
+        <ActiveItemsGrid
+          allItems={allBuildItems}
+          assignments={assignments}
+          activeError={activeError}
+          onToggleActive={onToggleActive}
+        />
+      ) : null}
+
+      {/* Mode toggle */}
+      <div
+        style={{
+          display: "flex",
+          gap: 4,
+          padding: 3,
+          background: "rgba(255,255,255,0.06)",
+          borderRadius: 8,
+          border: "1px solid rgba(255,255,255,0.1)",
+        }}
+      >
+        {(["plan", "active"] as const).map((m) => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            style={{
+              flex: 1,
+              padding: "5px 8px",
+              borderRadius: 6,
+              border: "none",
+              background: mode === m ? "rgba(255,255,255,0.12)" : "transparent",
+              color: "inherit",
+              fontSize: 12,
+              fontWeight: mode === m ? 700 : 400,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {m === "plan" ? "Full Plan" : "Active Build"}
+          </button>
+        ))}
+      </div>
+
       {/* Section 1: Soul Cost Split Bar */}
       <section>
         <div

--- a/app/build/components/CategoryManager.tsx
+++ b/app/build/components/CategoryManager.tsx
@@ -20,7 +20,15 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { BuildCategory, Item, ItemCategory } from "@/lib/items";
+import type {
+  BuildCategory,
+  Item,
+  ItemCategory,
+  ItemAssignment,
+  ItemDestination,
+  ItemPhase,
+} from "@/lib/items";
+import { getSellRefund } from "@/lib/buildCalculations";
 
 const CATEGORY_META: Record<
   ItemCategory,
@@ -29,6 +37,12 @@ const CATEGORY_META: Record<
   gun: { label: "Gun", solid: "#ea580c", accentSoft: "rgba(234,88,12,0.08)" },
   vitality: { label: "Vitality", solid: "#16a34a", accentSoft: "rgba(22,163,74,0.08)" },
   spirit: { label: "Spirit", solid: "#7c3aed", accentSoft: "rgba(124,58,237,0.08)" },
+};
+
+const PHASE_META: Record<ItemPhase, { label: string; accent: string; bg: string }> = {
+  early: { label: "Early Game", accent: "#eab308", bg: "rgba(234,179,8,0.08)" },
+  mid: { label: "Mid Game", accent: "#3b82f6", bg: "rgba(59,130,246,0.08)" },
+  late: { label: "Late Game", accent: "#ef4444", bg: "rgba(239,68,68,0.08)" },
 };
 
 function accentFor(item: Item): string {
@@ -54,18 +68,137 @@ function DroppableZone({ id, children }: { id: string; children: React.ReactNode
   );
 }
 
-// ─── Sortable item ────────────────────────────────────────────────────────────
+// ─── Flag buttons ─────────────────────────────────────────────────────────────
+
+function StarButton({
+  isActive,
+  isOptional,
+  activeFull,
+  onToggle,
+}: {
+  isActive: boolean;
+  isOptional: boolean;
+  activeFull: boolean;
+  onToggle: () => void;
+}) {
+  const disabled = isOptional || (activeFull && !isActive);
+  const title = isOptional
+    ? "Optional items cannot be active"
+    : activeFull && !isActive
+      ? "Active build full — remove an active item first"
+      : isActive
+        ? "Remove from active build"
+        : "Mark as active build item";
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!disabled) onToggle();
+      }}
+      title={title}
+      style={{
+        padding: 0,
+        background: "none",
+        border: "none",
+        cursor: disabled ? "not-allowed" : "pointer",
+        flexShrink: 0,
+        fontSize: 20,
+        lineHeight: 1,
+        color: isActive ? "#facc15" : "rgba(255,255,255,0.3)",
+        opacity: disabled ? 0.35 : 1,
+        width: 22,
+        textAlign: "center",
+        transition: "color 0.12s, opacity 0.12s",
+      }}
+    >
+      {isActive ? "★" : "☆"}
+    </button>
+  );
+}
+
+function SellButton({ isSell, onToggle }: { isSell: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      title={isSell ? "Remove sell priority" : "Mark as sell priority"}
+      style={{
+        padding: 0,
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        flexShrink: 0,
+        fontSize: 13,
+        lineHeight: 1,
+        color: isSell ? "#f87171" : "rgba(255,255,255,0.22)",
+        width: 18,
+        textAlign: "center",
+        transition: "color 0.12s",
+      }}
+    >
+      💰
+    </button>
+  );
+}
+
+function OptionalButton({ isOptional, onToggle }: { isOptional: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      title={isOptional ? "Remove optional flag" : "Mark as optional"}
+      style={{
+        padding: "0 2px",
+        background: "none",
+        border: isOptional ? "1px dashed rgba(255,255,255,0.45)" : "1px dashed transparent",
+        borderRadius: 3,
+        cursor: "pointer",
+        flexShrink: 0,
+        fontSize: 12,
+        fontWeight: 700,
+        lineHeight: 1,
+        color: isOptional ? "rgba(255,255,255,0.65)" : "rgba(255,255,255,0.2)",
+        width: 18,
+        textAlign: "center",
+        transition: "color 0.12s, border-color 0.12s",
+      }}
+    >
+      ?
+    </button>
+  );
+}
+
+// ─── Sortable item (used in uncategorized + user categories) ──────────────────
 
 function SortableItem({
   item,
   categoryId,
   onRemove,
   consumed,
+  onToggleActive,
+  isActive,
+  isOptional,
+  isSellPriority,
+  activeFull,
+  onToggleSell,
+  onToggleOptional,
 }: {
   item: Item;
   categoryId: string | null;
   onRemove: (itemId: string) => void;
   consumed: boolean;
+  onToggleActive?: (itemId: string) => void;
+  isActive?: boolean;
+  isOptional?: boolean;
+  isSellPriority?: boolean;
+  activeFull?: boolean;
+  onToggleSell?: (itemId: string) => void;
+  onToggleOptional?: (itemId: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.id,
@@ -81,7 +214,7 @@ function SortableItem({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.4 : consumed ? 0.5 : 1,
+    opacity: isDragging ? 0.4 : consumed ? 0.5 : isOptional ? 0.6 : 1,
   };
 
   return (
@@ -91,8 +224,10 @@ function SortableItem({
         ...style,
         display: "flex",
         alignItems: "center",
-        gap: 10,
-        border: "1px solid rgba(255,255,255,0.10)",
+        gap: 6,
+        border: isOptional
+          ? "1px dashed rgba(255,255,255,0.25)"
+          : "1px solid rgba(255,255,255,0.10)",
         borderLeft: `4px solid ${accentColor}`,
         borderRadius: 12,
         padding: "0 10px",
@@ -108,6 +243,25 @@ function SortableItem({
       {...attributes}
       {...listeners}
     >
+      {/* Flag buttons */}
+      {onToggleActive ? (
+        <StarButton
+          isActive={isActive ?? false}
+          isOptional={isOptional ?? false}
+          activeFull={activeFull ?? false}
+          onToggle={() => onToggleActive(item.id)}
+        />
+      ) : null}
+      {onToggleSell ? (
+        <SellButton isSell={isSellPriority ?? false} onToggle={() => onToggleSell(item.id)} />
+      ) : null}
+      {onToggleOptional ? (
+        <OptionalButton
+          isOptional={isOptional ?? false}
+          onToggle={() => onToggleOptional(item.id)}
+        />
+      ) : null}
+
       {/* Icon */}
       {item.icon ? (
         // eslint-disable-next-line @next/next/no-img-element
@@ -161,6 +315,12 @@ function SortableItem({
           <span>T{item.tier}</span>
           <span>·</span>
           <span>${item.cost.toLocaleString("en-US")}</span>
+          {isOptional ? (
+            <>
+              <span>·</span>
+              <span style={{ color: "rgba(255,255,255,0.5)", fontStyle: "italic" }}>Optional</span>
+            </>
+          ) : null}
         </div>
       </div>
 
@@ -205,20 +365,602 @@ function SortableItem({
   );
 }
 
+// ─── Sortable phase-section item ──────────────────────────────────────────────
+
+function DraggableFixedItem({
+  item,
+  sectionId,
+  onRemoveFromSection,
+  onRemoveBuildItem,
+  consumed,
+  extraInfo,
+  onToggleActive,
+  isActive,
+  activeFull,
+  isSellPriority,
+  isOptional,
+  onToggleSell,
+  onToggleOptional,
+}: {
+  item: Item;
+  sectionId: string;
+  onRemoveFromSection: (itemId: string) => void;
+  onRemoveBuildItem: (itemId: string) => void;
+  consumed: boolean;
+  extraInfo?: string;
+  onToggleActive?: (itemId: string) => void;
+  isActive?: boolean;
+  activeFull?: boolean;
+  isSellPriority?: boolean;
+  isOptional?: boolean;
+  onToggleSell?: (itemId: string) => void;
+  onToggleOptional?: (itemId: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+    data: { type: "item", categoryId: sectionId },
+  });
+
+  const [hovered, setHovered] = useState(false);
+  const [removeHovered, setRemoveHovered] = useState(false);
+  const [sectionRemoveHovered, setSectionRemoveHovered] = useState(false);
+
+  const meta = CATEGORY_META[item.category];
+  const accentColor = consumed ? "#6b7280" : meta.solid;
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : consumed ? 0.5 : isOptional ? 0.6 : 1,
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        border: isOptional
+          ? "1px dashed rgba(255,255,255,0.25)"
+          : "1px solid rgba(255,255,255,0.10)",
+        borderLeft: `4px solid ${accentColor}`,
+        borderRadius: 12,
+        padding: "0 10px",
+        height: 60,
+        boxSizing: "border-box",
+        background: hovered && !consumed ? "rgba(255,255,255,0.06)" : meta.accentSoft,
+        cursor: consumed ? "default" : "grab",
+        overflow: "hidden",
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      {...attributes}
+      {...listeners}
+    >
+      {/* Flag buttons */}
+      {onToggleActive ? (
+        <StarButton
+          isActive={isActive ?? false}
+          isOptional={isOptional ?? false}
+          activeFull={activeFull ?? false}
+          onToggle={() => onToggleActive(item.id)}
+        />
+      ) : null}
+      {onToggleSell ? (
+        <SellButton isSell={isSellPriority ?? false} onToggle={() => onToggleSell(item.id)} />
+      ) : null}
+      {onToggleOptional ? (
+        <OptionalButton
+          isOptional={isOptional ?? false}
+          onToggle={() => onToggleOptional(item.id)}
+        />
+      ) : null}
+
+      {/* Icon */}
+      {item.icon ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={item.icon}
+          alt={item.name}
+          width={32}
+          height={32}
+          style={{ borderRadius: 8, flexShrink: 0 }}
+        />
+      ) : (
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 8,
+            background: "rgba(255,255,255,0.08)",
+            flexShrink: 0,
+          }}
+        />
+      )}
+
+      {/* Name + sub-line */}
+      <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: 13,
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={item.name}
+        >
+          {item.name}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: 5,
+            marginTop: 3,
+            alignItems: "center",
+            fontSize: 11,
+            opacity: 0.75,
+          }}
+        >
+          <span style={{ color: meta.solid }}>{meta.label}</span>
+          <span>·</span>
+          <span>T{item.tier}</span>
+          <span>·</span>
+          <span>${item.cost.toLocaleString("en-US")}</span>
+        </div>
+        {extraInfo ? (
+          <div style={{ fontSize: 11, opacity: 0.6, marginTop: 1 }}>{extraInfo}</div>
+        ) : null}
+      </div>
+
+      {/* Section-remove + build-remove buttons */}
+      <div
+        style={{ display: "flex", gap: 4, flexShrink: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemoveFromSection(item.id);
+          }}
+          onMouseEnter={() => setSectionRemoveHovered(true)}
+          onMouseLeave={() => setSectionRemoveHovered(false)}
+          title="Return to Uncategorized"
+          style={{
+            padding: "3px 6px",
+            borderRadius: 6,
+            border: "1px solid rgba(255,255,255,0.12)",
+            background: sectionRemoveHovered ? "rgba(255,255,255,0.1)" : "transparent",
+            color: sectionRemoveHovered ? "rgba(255,255,255,0.8)" : "rgba(255,255,255,0.4)",
+            cursor: "pointer",
+            fontSize: 12,
+            transition: "background 0.12s, color 0.12s",
+            lineHeight: 1,
+          }}
+          aria-label={`Remove ${item.name} from section`}
+        >
+          ↩
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemoveBuildItem(item.id);
+          }}
+          onMouseEnter={() => setRemoveHovered(true)}
+          onMouseLeave={() => setRemoveHovered(false)}
+          title="Remove from build"
+          style={{
+            padding: "3px 8px",
+            borderRadius: 6,
+            border: "1px solid rgba(255,255,255,0.12)",
+            background: removeHovered ? "rgba(239,68,68,0.15)" : "transparent",
+            color: removeHovered ? "#f87171" : "rgba(255,255,255,0.4)",
+            cursor: "pointer",
+            fontSize: 13,
+            transition: "background 0.12s, color 0.12s",
+            lineHeight: 1,
+          }}
+          aria-label={`Remove ${item.name} from build`}
+        >
+          ✕
+        </button>
+      </div>
+    </li>
+  );
+}
+
+// ─── Filter view item (non-draggable, for sell/optional sections) ─────────────
+
+function FilterViewItem({
+  item,
+  flagType,
+  onToggleFlag,
+  extraInfo,
+  consumedComponents,
+}: {
+  item: Item;
+  flagType: "sell" | "optional";
+  onToggleFlag: (itemId: string) => void;
+  extraInfo?: string;
+  consumedComponents: Map<string, string>;
+}) {
+  const meta = CATEGORY_META[item.category];
+  const accentColor = consumedComponents.has(item.id) ? "#6b7280" : meta.solid;
+  const [hovered, setHovered] = useState(false);
+  const [btnHovered, setBtnHovered] = useState(false);
+
+  return (
+    <li
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderLeft: `4px solid ${accentColor}`,
+        borderRadius: 12,
+        padding: "0 10px",
+        height: 52,
+        boxSizing: "border-box",
+        background: hovered ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)",
+        transition: "background 0.15s",
+        overflow: "hidden",
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {/* Icon */}
+      {item.icon ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={item.icon}
+          alt={item.name}
+          width={28}
+          height={28}
+          style={{ borderRadius: 6, flexShrink: 0 }}
+        />
+      ) : (
+        <div
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 6,
+            background: "rgba(255,255,255,0.08)",
+            flexShrink: 0,
+          }}
+        />
+      )}
+
+      {/* Name + extra info */}
+      <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
+        <div
+          style={{
+            fontWeight: 700,
+            fontSize: 12,
+            lineHeight: 1.2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={item.name}
+        >
+          {item.name}
+        </div>
+        {extraInfo ? (
+          <div style={{ fontSize: 11, opacity: 0.6, marginTop: 2 }}>{extraInfo}</div>
+        ) : null}
+      </div>
+
+      {/* Unflag button */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleFlag(item.id);
+        }}
+        onMouseEnter={() => setBtnHovered(true)}
+        onMouseLeave={() => setBtnHovered(false)}
+        title={flagType === "sell" ? "Remove sell priority" : "Remove optional flag"}
+        style={{
+          padding: "3px 7px",
+          borderRadius: 6,
+          border:
+            flagType === "sell"
+              ? "1px solid rgba(239,68,68,0.4)"
+              : "1px dashed rgba(255,255,255,0.3)",
+          background: btnHovered
+            ? flagType === "sell"
+              ? "rgba(239,68,68,0.15)"
+              : "rgba(255,255,255,0.07)"
+            : "transparent",
+          color: flagType === "sell" ? "#f87171" : "rgba(255,255,255,0.55)",
+          cursor: "pointer",
+          fontSize: 11,
+          flexShrink: 0,
+          transition: "background 0.12s",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {flagType === "sell" ? "💰 Remove" : "? Remove"}
+      </button>
+    </li>
+  );
+}
+
+// ─── Collapsible phase section (sortable items, droppable zone) ───────────────
+
+function CollapsibleFixedSection({
+  zoneId,
+  label,
+  accentColor,
+  bg,
+  headerExtra,
+  items,
+  onRemoveFromSection,
+  onRemoveBuildItem,
+  consumedComponents,
+  onToggleActive,
+  assignments,
+  activeFull,
+  onToggleSell,
+  onToggleOptional,
+}: {
+  zoneId: string;
+  label: string;
+  accentColor: string;
+  bg: string;
+  headerExtra?: string;
+  items: Item[];
+  onRemoveFromSection: (itemId: string) => void;
+  onRemoveBuildItem: (itemId: string) => void;
+  consumedComponents: Map<string, string>;
+  onToggleActive?: (itemId: string) => void;
+  assignments: ItemAssignment[];
+  activeFull?: boolean;
+  onToggleSell?: (itemId: string) => void;
+  onToggleOptional?: (itemId: string) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(items.length === 0);
+  const { setNodeRef, isOver } = useDroppable({ id: zoneId });
+
+  const showContent = !collapsed || isOver;
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${accentColor}33`,
+        borderRadius: 12,
+        overflow: "hidden",
+        background: bg,
+      }}
+    >
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "10px 12px",
+          background: "transparent",
+          border: "none",
+          color: "inherit",
+          cursor: "pointer",
+          textAlign: "left",
+          borderBottom: showContent ? `1px solid ${accentColor}22` : "none",
+        }}
+      >
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: 2,
+            background: accentColor,
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 700, fontSize: 14, flex: 1, color: accentColor }}>
+          {label}
+        </span>
+        {items.length > 0 ? (
+          <span style={{ fontSize: 12, opacity: 0.6 }}>{items.length}</span>
+        ) : null}
+        {headerExtra ? (
+          <span style={{ fontSize: 11, opacity: 0.6 }}>{headerExtra}</span>
+        ) : null}
+        <span style={{ fontSize: 11, opacity: 0.45 }}>{collapsed && !isOver ? "▶" : "▼"}</span>
+      </button>
+
+      {/* Drop zone + sortable content */}
+      <div ref={setNodeRef}>
+        {showContent ? (
+          <div style={{ padding: items.length === 0 ? "10px 12px" : "8px 12px" }}>
+            {items.length === 0 ? (
+              <div
+                style={{
+                  fontSize: 12,
+                  opacity: 0.4,
+                  fontStyle: "italic",
+                  textAlign: "center",
+                  padding: "8px 0",
+                  border: `1px dashed ${accentColor}44`,
+                  borderRadius: 8,
+                }}
+              >
+                Drop items here
+              </div>
+            ) : (
+              <SortableContext
+                items={items.map((i) => i.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <ul
+                  style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 6 }}
+                >
+                  {items.map((item) => {
+                    const assignment = assignments.find((a) => a.itemId === item.id);
+                    return (
+                      <DraggableFixedItem
+                        key={item.id}
+                        item={item}
+                        sectionId={zoneId}
+                        onRemoveFromSection={onRemoveFromSection}
+                        onRemoveBuildItem={onRemoveBuildItem}
+                        consumed={consumedComponents.has(item.id)}
+                        onToggleActive={onToggleActive}
+                        isActive={assignment?.active ?? false}
+                        activeFull={activeFull}
+                        isSellPriority={assignment?.sellPriority ?? false}
+                        isOptional={assignment?.optional ?? false}
+                        onToggleSell={onToggleSell}
+                        onToggleOptional={onToggleOptional}
+                      />
+                    );
+                  })}
+                </ul>
+              </SortableContext>
+            )}
+          </div>
+        ) : (
+          <div style={{ height: 6 }} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Flag filter section (non-droppable, read-only view) ─────────────────────
+
+function FlagFilterSection({
+  label,
+  accentColor,
+  bg,
+  headerExtra,
+  items,
+  consumedComponents,
+  renderItemExtra,
+  onToggleFlag,
+  flagType,
+}: {
+  label: string;
+  accentColor: string;
+  bg: string;
+  headerExtra?: string;
+  items: Item[];
+  consumedComponents: Map<string, string>;
+  renderItemExtra?: (item: Item) => string | undefined;
+  onToggleFlag: (itemId: string) => void;
+  flagType: "sell" | "optional";
+}) {
+  const [collapsed, setCollapsed] = useState(items.length === 0);
+  const showContent = !collapsed;
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${accentColor}33`,
+        borderRadius: 12,
+        overflow: "hidden",
+        background: bg,
+      }}
+    >
+      {/* Header */}
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "10px 12px",
+          background: "transparent",
+          border: "none",
+          color: "inherit",
+          cursor: "pointer",
+          textAlign: "left",
+          borderBottom: showContent ? `1px solid ${accentColor}22` : "none",
+        }}
+      >
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: 2,
+            background: accentColor,
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 700, fontSize: 14, flex: 1, color: accentColor }}>
+          {label}
+        </span>
+        {items.length > 0 ? (
+          <span style={{ fontSize: 12, opacity: 0.6 }}>{items.length}</span>
+        ) : null}
+        {headerExtra ? (
+          <span style={{ fontSize: 11, opacity: 0.6 }}>{headerExtra}</span>
+        ) : null}
+        <span style={{ fontSize: 11, opacity: 0.45 }}>{collapsed ? "▶" : "▼"}</span>
+      </button>
+
+      {/* Content — no droppable zone */}
+      {showContent ? (
+        <div style={{ padding: items.length === 0 ? "10px 12px" : "8px 12px" }}>
+          {items.length === 0 ? (
+            <div
+              style={{
+                fontSize: 12,
+                opacity: 0.4,
+                fontStyle: "italic",
+                textAlign: "center",
+                padding: "8px 0",
+              }}
+            >
+              No {flagType === "sell" ? "sell priority" : "optional"} items
+            </div>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 6 }}>
+              {items.map((item) => (
+                <FilterViewItem
+                  key={item.id}
+                  item={item}
+                  flagType={flagType}
+                  onToggleFlag={onToggleFlag}
+                  extraInfo={renderItemExtra?.(item)}
+                  consumedComponents={consumedComponents}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 // ─── Sortable category row ────────────────────────────────────────────────────
 
 function SortableCategory({
   category,
   items,
   onRename,
+  onDelete,
   onRemoveFromCategory,
   consumedComponents,
+  onToggleActive,
+  onToggleSell,
+  onToggleOptional,
+  assignments,
+  activeFull,
 }: {
   category: BuildCategory;
   items: Item[];
   onRename: (id: string, name: string) => void;
+  onDelete: (id: string) => void;
   onRemoveFromCategory: (categoryId: string, itemId: string) => void;
   consumedComponents: Map<string, string>;
+  onToggleActive: (itemId: string) => void;
+  onToggleSell: (itemId: string) => void;
+  onToggleOptional: (itemId: string) => void;
+  assignments: ItemAssignment[];
+  activeFull: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: category.id,
@@ -233,6 +975,7 @@ function SortableCategory({
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(category.name);
+  const [deleteHovered, setDeleteHovered] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   function startEdit() {
@@ -315,6 +1058,27 @@ function SortableCategory({
           )}
 
           <button
+            onClick={() => onDelete(category.id)}
+            onMouseEnter={() => setDeleteHovered(true)}
+            onMouseLeave={() => setDeleteHovered(false)}
+            style={{
+              background: "none",
+              border: "none",
+              color: deleteHovered ? "#f87171" : "rgba(255,255,255,0.3)",
+              cursor: "pointer",
+              padding: "2px 4px",
+              fontSize: 13,
+              lineHeight: 1,
+              flexShrink: 0,
+              transition: "color 0.12s",
+            }}
+            title="Delete category"
+            aria-label="Delete category"
+          >
+            ✕
+          </button>
+
+          <button
             {...attributes}
             {...listeners}
             style={{
@@ -334,7 +1098,7 @@ function SortableCategory({
           </button>
         </div>
 
-        {/* Items — DroppableZone registers this area as a drop target */}
+        {/* Items */}
         <DroppableZone id={`zone-${category.id}`}>
           <div style={{ padding: category.itemIds.length === 0 ? "10px 12px" : "8px 12px" }}>
             {category.itemIds.length === 0 ? (
@@ -356,15 +1120,25 @@ function SortableCategory({
                 <ul
                   style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 6 }}
                 >
-                  {items.map((item) => (
-                    <SortableItem
-                      key={item.id}
-                      item={item}
-                      categoryId={category.id}
-                      onRemove={(itemId) => onRemoveFromCategory(category.id, itemId)}
-                      consumed={consumedComponents.has(item.id)}
-                    />
-                  ))}
+                  {items.map((item) => {
+                    const assignment = assignments.find((a) => a.itemId === item.id);
+                    return (
+                      <SortableItem
+                        key={item.id}
+                        item={item}
+                        categoryId={category.id}
+                        onRemove={(itemId) => onRemoveFromCategory(category.id, itemId)}
+                        consumed={consumedComponents.has(item.id)}
+                        onToggleActive={onToggleActive}
+                        isActive={assignment?.active ?? false}
+                        isOptional={assignment?.optional ?? false}
+                        isSellPriority={assignment?.sellPriority ?? false}
+                        activeFull={activeFull}
+                        onToggleSell={onToggleSell}
+                        onToggleOptional={onToggleOptional}
+                      />
+                    );
+                  })}
                 </ul>
               </SortableContext>
             )}
@@ -377,18 +1151,11 @@ function SortableCategory({
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function findCategoryOfItem(
-  itemId: string,
-  categories: BuildCategory[],
-): BuildCategory | null {
+function findCategoryOfItem(itemId: string, categories: BuildCategory[]): BuildCategory | null {
   return categories.find((c) => c.itemIds.includes(itemId)) ?? null;
 }
 
-// overId may be a category id, an item id within a category, or "zone-{categoryId}"
-function findTargetCategory(
-  overId: string,
-  categories: BuildCategory[],
-): BuildCategory | null {
+function findTargetCategory(overId: string, categories: BuildCategory[]): BuildCategory | null {
   if (overId.startsWith("zone-")) {
     const categoryId = overId.slice(5);
     return categories.find((c) => c.id === categoryId) ?? null;
@@ -396,29 +1163,83 @@ function findTargetCategory(
   return categories.find((c) => c.id === overId || c.itemIds.includes(overId)) ?? null;
 }
 
+// Only phase zones are valid drag destinations now
+const FIXED_ZONE_MAP: Record<string, ItemDestination> = {
+  "zone-phase-early": { type: "phase", phase: "early" },
+  "zone-phase-mid": { type: "phase", phase: "mid" },
+  "zone-phase-late": { type: "phase", phase: "late" },
+};
+
+function getFixedDestination(overId: string): ItemDestination | null {
+  return FIXED_ZONE_MAP[overId] ?? null;
+}
+
+function getCurrentPhaseZone(itemId: string, assignments: ItemAssignment[]): string | null {
+  const a = assignments.find((x) => x.itemId === itemId);
+  if (!a?.phase) return null;
+  return `zone-phase-${a.phase}`;
+}
+
 // ─── Main CategoryManager ─────────────────────────────────────────────────────
 
 export function CategoryManager({
   categories,
   buildItems,
+  itemAssignments,
   onCategoriesChange,
+  onItemMove,
   onRemoveBuildItem,
+  onToggleActive,
+  onToggleSellPriority,
+  onToggleOptional,
+  onReorderBuildItems,
   consumedComponents,
 }: {
   categories: BuildCategory[];
   buildItems: Item[];
+  itemAssignments: ItemAssignment[];
   onCategoriesChange: (categories: BuildCategory[]) => void;
+  onItemMove: (itemId: string, dest: ItemDestination) => void;
   onRemoveBuildItem: (itemId: string) => void;
+  onToggleActive: (itemId: string) => void;
+  onToggleSellPriority: (itemId: string) => void;
+  onToggleOptional: (itemId: string) => void;
+  onReorderBuildItems: (itemId: string, overId: string) => void;
   consumedComponents: Map<string, string>;
 }) {
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
 
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
 
-  const assignedItemIds = new Set(categories.flatMap((c) => c.itemIds));
-  const uncategorizedItems = buildItems.filter((it) => !assignedItemIds.has(it.id));
+  const activeFull = itemAssignments.filter((a) => a.active).length >= 12;
+
+  // Only phase assignments exclude items from uncategorized/user categories
+  const fixedItemIds = new Set(
+    itemAssignments.filter((a) => a.phase !== null).map((a) => a.itemId),
+  );
+
+  const assignedCategoryItemIds = new Set(categories.flatMap((c) => c.itemIds));
+  const uncategorizedItems = buildItems.filter(
+    (it) => !fixedItemIds.has(it.id) && !assignedCategoryItemIds.has(it.id),
+  );
 
   const itemById = new Map(buildItems.map((it) => [it.id, it]));
+
+  // Derive per-section item lists
+  const phaseItems = (phase: ItemPhase) =>
+    buildItems.filter((it) => itemAssignments.find((a) => a.itemId === it.id)?.phase === phase);
+
+  // Sell/optional are flags — items can be anywhere AND have these flags
+  const sellItems = buildItems.filter(
+    (it) => itemAssignments.find((a) => a.itemId === it.id)?.sellPriority,
+  );
+  const optionalItems = buildItems.filter(
+    (it) => itemAssignments.find((a) => a.itemId === it.id)?.optional,
+  );
+
+  const totalSellValue = sellItems.reduce((sum, it) => sum + getSellRefund(it.cost), 0);
 
   function addCategory() {
     onCategoriesChange([
@@ -429,6 +1250,10 @@ export function CategoryManager({
 
   function handleRename(id: string, name: string) {
     onCategoriesChange(categories.map((c) => (c.id === id ? { ...c, name } : c)));
+  }
+
+  function handleDeleteCategory(id: string) {
+    onCategoriesChange(categories.filter((c) => c.id !== id));
   }
 
   function handleRemoveFromCategory(categoryId: string, itemId: string) {
@@ -456,39 +1281,44 @@ export function CategoryManager({
     const itemId = String(active.id);
     const overId = String(over.id);
 
+    // 1. Hovering over a phase zone (the zone background itself)
+    const fixedDest = getFixedDestination(overId);
+    if (fixedDest && fixedDest.type === "phase") {
+      const currentZone = getCurrentPhaseZone(itemId, itemAssignments);
+      const destZoneId = `zone-phase-${fixedDest.phase}`;
+      if (currentZone === destZoneId) return;
+      onItemMove(itemId, fixedDest);
+      return;
+    }
+
+    // 2. Hovering over an item that belongs to a phase (cross-phase or within-phase)
+    const overItemPhase =
+      itemAssignments.find((a) => a.itemId === overId)?.phase ?? null;
+    if (overItemPhase !== null) {
+      const curPhase = itemAssignments.find((a) => a.itemId === itemId)?.phase ?? null;
+      if (curPhase === overItemPhase) return; // Same phase — SortableContext handles visual
+      onItemMove(itemId, { type: "phase", phase: overItemPhase });
+      return;
+    }
+
+    // 3. Hovering over uncategorized zone or uncategorized item
     const currentCategory = findCategoryOfItem(itemId, categories);
     const currentCategoryId = currentCategory?.id ?? "uncategorized";
 
-    // Hovering over the uncategorized zone or an uncategorized item
     const isOverUncategorized =
       overId === "uncategorized" || uncategorizedItems.some((it) => it.id === overId);
 
     if (isOverUncategorized) {
-      if (currentCategoryId === "uncategorized") return;
-      onCategoriesChange(
-        categories.map((c) =>
-          c.id === currentCategoryId
-            ? { ...c, itemIds: c.itemIds.filter((id) => id !== itemId) }
-            : c,
-        ),
-      );
+      const currentZone = getCurrentPhaseZone(itemId, itemAssignments);
+      if (currentCategoryId === "uncategorized" && currentZone === null) return;
+      onItemMove(itemId, { type: "uncategorized" });
       return;
     }
 
+    // 4. Hovering over a user category
     const targetCategory = findTargetCategory(overId, categories);
     if (!targetCategory || targetCategory.id === currentCategoryId) return;
-
-    onCategoriesChange(
-      categories.map((c) => {
-        if (c.id === currentCategoryId) {
-          return { ...c, itemIds: c.itemIds.filter((id) => id !== itemId) };
-        }
-        if (c.id === targetCategory.id) {
-          return { ...c, itemIds: [...c.itemIds, itemId] };
-        }
-        return c;
-      }),
-    );
+    onItemMove(itemId, { type: "category", categoryId: targetCategory.id });
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -499,6 +1329,7 @@ export function CategoryManager({
 
     const activeData = active.data.current as { type?: string } | undefined;
 
+    // Category reorder
     if (activeData?.type === "category") {
       const activeId = String(active.id);
       const overId = String(over.id);
@@ -514,7 +1345,7 @@ export function CategoryManager({
       const itemId = String(active.id);
       const overId = String(over.id);
 
-      // Same-category reorder: both item and over target are in the same category
+      // Same user-category reorder
       const itemCategory = findCategoryOfItem(itemId, categories);
       if (itemCategory && itemCategory.itemIds.includes(overId)) {
         const oldIndex = itemCategory.itemIds.indexOf(itemId);
@@ -529,20 +1360,32 @@ export function CategoryManager({
         return;
       }
 
-      // Drop onto uncategorized sentinel — onDragOver may not have caught it
-      if (overId === "uncategorized" && itemCategory) {
-        onCategoriesChange(
-          categories.map((c) => ({ ...c, itemIds: c.itemIds.filter((id) => id !== itemId) })),
-        );
+      // Same phase reorder
+      const activePhase = itemAssignments.find((a) => a.itemId === itemId)?.phase ?? null;
+      const overPhase = itemAssignments.find((a) => a.itemId === overId)?.phase ?? null;
+      if (activePhase !== null && activePhase === overPhase) {
+        onReorderBuildItems(itemId, overId);
+        return;
       }
 
-      // All other cross-category moves were already handled by onDragOver
+      // All other cross-zone moves are handled live by onDragOver
     }
   }
 
   const categoryIds = categories.map((c) => c.id);
   const uncatItemIds = uncategorizedItems.map((it) => it.id);
   const activeItem = activeItemId ? itemById.get(activeItemId) : null;
+
+  const phases: ItemPhase[] = ["early", "mid", "late"];
+
+  // Helper: get location label for filter view items
+  function getLocationLabel(itemId: string): string {
+    const a = itemAssignments.find((x) => x.itemId === itemId);
+    if (a?.phase) return PHASE_META[a.phase].label;
+    const cat = categories.find((c) => c.itemIds.includes(itemId));
+    if (cat) return cat.name;
+    return "Uncategorized";
+  }
 
   return (
     <DndContext
@@ -579,7 +1422,63 @@ export function CategoryManager({
           </button>
         </div>
 
-        <div style={{ display: "grid", gap: 16 }}>
+        <div style={{ display: "grid", gap: 10 }}>
+          {/* Phase sections — sortable, droppable */}
+          {phases.map((phase) => {
+            const meta = PHASE_META[phase];
+            const items = phaseItems(phase);
+            return (
+              <CollapsibleFixedSection
+                key={phase}
+                zoneId={`zone-phase-${phase}`}
+                label={meta.label}
+                accentColor={meta.accent}
+                bg={meta.bg}
+                items={items}
+                onRemoveFromSection={(itemId) => onItemMove(itemId, { type: "uncategorized" })}
+                onRemoveBuildItem={onRemoveBuildItem}
+                consumedComponents={consumedComponents}
+                onToggleActive={onToggleActive}
+                onToggleSell={onToggleSellPriority}
+                onToggleOptional={onToggleOptional}
+                assignments={itemAssignments}
+                activeFull={activeFull}
+              />
+            );
+          })}
+
+          {/* Sell Priority — flag filter view, not a drag destination */}
+          <FlagFilterSection
+            label="Sell Priority"
+            accentColor="#ef4444"
+            bg="rgba(239,68,68,0.06)"
+            headerExtra={
+              totalSellValue > 0
+                ? `~$${totalSellValue.toLocaleString("en-US")} back`
+                : undefined
+            }
+            items={sellItems}
+            consumedComponents={consumedComponents}
+            renderItemExtra={(item) => {
+              const location = getLocationLabel(item.id);
+              return `${location} · Sells for $${getSellRefund(item.cost).toLocaleString("en-US")} souls`;
+            }}
+            onToggleFlag={onToggleSellPriority}
+            flagType="sell"
+          />
+
+          {/* Optional — flag filter view, not a drag destination */}
+          <FlagFilterSection
+            label="Optional"
+            accentColor="#6b7280"
+            bg="rgba(107,114,128,0.06)"
+            items={optionalItems}
+            consumedComponents={consumedComponents}
+            renderItemExtra={(item) => getLocationLabel(item.id)}
+            onToggleFlag={onToggleOptional}
+            flagType="optional"
+          />
+
           {/* Uncategorized section */}
           <div>
             <div
@@ -623,15 +1522,25 @@ export function CategoryManager({
                         gap: 6,
                       }}
                     >
-                      {uncategorizedItems.map((item) => (
-                        <SortableItem
-                          key={item.id}
-                          item={item}
-                          categoryId={null}
-                          onRemove={onRemoveBuildItem}
-                          consumed={consumedComponents.has(item.id)}
-                        />
-                      ))}
+                      {uncategorizedItems.map((item) => {
+                        const assignment = itemAssignments.find((a) => a.itemId === item.id);
+                        return (
+                          <SortableItem
+                            key={item.id}
+                            item={item}
+                            categoryId={null}
+                            onRemove={onRemoveBuildItem}
+                            consumed={consumedComponents.has(item.id)}
+                            onToggleActive={onToggleActive}
+                            isActive={assignment?.active ?? false}
+                            isOptional={assignment?.optional ?? false}
+                            isSellPriority={assignment?.sellPriority ?? false}
+                            activeFull={activeFull}
+                            onToggleSell={onToggleSellPriority}
+                            onToggleOptional={onToggleOptional}
+                          />
+                        );
+                      })}
                     </ul>
                   </SortableContext>
                 )}
@@ -653,8 +1562,14 @@ export function CategoryManager({
                     category={cat}
                     items={catItems}
                     onRename={handleRename}
+                    onDelete={handleDeleteCategory}
                     onRemoveFromCategory={handleRemoveFromCategory}
                     consumedComponents={consumedComponents}
+                    onToggleActive={onToggleActive}
+                    onToggleSell={onToggleSellPriority}
+                    onToggleOptional={onToggleOptional}
+                    assignments={itemAssignments}
+                    activeFull={activeFull}
                   />
                 );
               })}

--- a/app/build/components/ItemBrowser.tsx
+++ b/app/build/components/ItemBrowser.tsx
@@ -142,7 +142,13 @@ export function ItemBrowser({
                       <li
                         key={it.id}
                         style={{
-                          border: isSelected
+                          borderTop: isSelected
+                            ? `2px solid ${meta.solid}`
+                            : "1px solid rgba(255,255,255,0.10)",
+                          borderRight: isSelected
+                            ? `2px solid ${meta.solid}`
+                            : "1px solid rgba(255,255,255,0.10)",
+                          borderBottom: isSelected
                             ? `2px solid ${meta.solid}`
                             : "1px solid rgba(255,255,255,0.10)",
                           borderLeft: `4px solid ${meta.solid}`,

--- a/lib/buildCalculations.ts
+++ b/lib/buildCalculations.ts
@@ -1,5 +1,19 @@
 import type { CategoryBonus } from "./categoryBonuses";
 import { getCurrentBonusTier, getSoulsToNextTier } from "./categoryBonuses";
+import type { Item, ItemAssignment } from "./items";
+
+export const SELL_REFUND_RATE = 0.5;
+export const getSellRefund = (cost: number): number => Math.floor(cost * SELL_REFUND_RATE);
+
+export function getActiveItems(items: Item[], assignments: ItemAssignment[]): Item[] {
+  const activeIds = new Set(assignments.filter((a) => a.active).map((a) => a.itemId));
+  return items.filter((it) => activeIds.has(it.id));
+}
+
+export function getPlanItems(items: Item[], assignments: ItemAssignment[]): Item[] {
+  const optionalIds = new Set(assignments.filter((a) => a.optional).map((a) => a.itemId));
+  return items.filter((it) => !optionalIds.has(it.id));
+}
 
 export type BuildableItem = {
   category: "gun" | "weapon" | "vitality" | "spirit";

--- a/lib/buildSerializer.ts
+++ b/lib/buildSerializer.ts
@@ -1,11 +1,16 @@
 import type { AbilityLevels, SignatureSlot, AbilityLevel } from "@/lib/deadlock";
-import type { BuildCategory } from "@/lib/items";
+import type { BuildCategory, ItemAssignment, ItemPhase } from "@/lib/items";
 
 export type BuildState = {
   heroId: string;
   itemIds: string[];
   abilityLevels: AbilityLevels;
   categories: BuildCategory[];
+  // Parallel arrays — index matches itemIds index
+  phases: Array<ItemPhase | null>;
+  active: boolean[];
+  sell: boolean[];
+  optional: boolean[];
 };
 
 export function serializeBuild(state: BuildState): string {
@@ -34,12 +39,46 @@ export function deserializeBuild(encoded: string): BuildState {
     throw new Error("Invalid build state: missing itemIds");
   }
 
+  const itemIds = (raw.itemIds as unknown[]).filter((id): id is string => typeof id === "string");
+  const len = itemIds.length;
+
   return {
     heroId: raw.heroId,
-    itemIds: (raw.itemIds as unknown[]).filter((id): id is string => typeof id === "string"),
+    itemIds,
     abilityLevels: parseAbilityLevels(raw.abilityLevels),
     categories: parseCategories(raw.categories),
+    phases: parsePhases(raw.phases, len),
+    active: parseBooleans(raw.active, len),
+    sell: parseBooleans(raw.sell, len),
+    optional: parseBooleans(raw.optional, len),
   };
+}
+
+export function getItemAssignments(state: BuildState): ItemAssignment[] {
+  return state.itemIds.map((itemId, i) => ({
+    itemId,
+    phase: state.phases[i] ?? null,
+    active: state.active[i] ?? false,
+    sellPriority: state.sell[i] ?? false,
+    optional: state.optional[i] ?? false,
+  }));
+}
+
+function isPhase(v: unknown): v is ItemPhase {
+  return v === "early" || v === "mid" || v === "late";
+}
+
+function parsePhases(raw: unknown, len: number): Array<ItemPhase | null> {
+  if (!Array.isArray(raw)) return new Array<ItemPhase | null>(len).fill(null);
+  return Array.from({ length: len }, (_, i) => {
+    const v = (raw as unknown[])[i];
+    return isPhase(v) ? v : null;
+  });
+}
+
+function parseBooleans(raw: unknown, len: number): boolean[] {
+  if (!Array.isArray(raw)) return new Array<boolean>(len).fill(false);
+  return Array.from({ length: len }, (_, i) => (raw as unknown[])[i] === true);
 }
 
 function parseAbilityLevels(raw: unknown): AbilityLevels {
@@ -75,9 +114,13 @@ if (process.env.NODE_ENV === "development") {
       itemIds: ["111", "222", "333"],
       abilityLevels: { signature1: 1, signature2: 2, signature4: 3 },
       categories: [
-        { id: "cat-1", name: "Early Game", itemIds: ["111"] },
-        { id: "cat-2", name: "Late Game", itemIds: ["222", "333"] },
+        { id: "cat-1", name: "Core", itemIds: ["111"] },
+        { id: "cat-2", name: "Situational", itemIds: ["222", "333"] },
       ],
+      phases: ["early", null, "late"],
+      active: [true, false, true],
+      sell: [false, true, false],
+      optional: [false, false, false],
     };
     try {
       const encoded = serializeBuild(testState);
@@ -86,12 +129,13 @@ if (process.env.NODE_ENV === "development") {
         decoded.heroId === testState.heroId &&
         decoded.itemIds.join(",") === testState.itemIds.join(",") &&
         JSON.stringify(decoded.abilityLevels) === JSON.stringify(testState.abilityLevels) &&
-        JSON.stringify(decoded.categories) === JSON.stringify(testState.categories);
+        JSON.stringify(decoded.categories) === JSON.stringify(testState.categories) &&
+        JSON.stringify(decoded.phases) === JSON.stringify(testState.phases) &&
+        JSON.stringify(decoded.active) === JSON.stringify(testState.active) &&
+        JSON.stringify(decoded.sell) === JSON.stringify(testState.sell) &&
+        JSON.stringify(decoded.optional) === JSON.stringify(testState.optional);
       if (!match) {
-        console.error("[buildSerializer] Round-trip test FAILED", {
-          testState,
-          decoded,
-        });
+        console.error("[buildSerializer] Round-trip test FAILED", { testState, decoded });
       }
     } catch (err) {
       console.error("[buildSerializer] Round-trip test threw", err);

--- a/lib/items.ts
+++ b/lib/items.ts
@@ -1,5 +1,20 @@
 export type ItemCategory = "gun" | "vitality" | "spirit";
 
+export type ItemPhase = "early" | "mid" | "late";
+
+export type ItemAssignment = {
+  itemId: string;
+  phase: ItemPhase | null;
+  active: boolean;
+  sellPriority: boolean;
+  optional: boolean;
+};
+
+export type ItemDestination =
+  | { type: "phase"; phase: ItemPhase }
+  | { type: "category"; categoryId: string }
+  | { type: "uncategorized" };
+
 export type BuildCategory = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
Completes Milestone 5a — evolves the build planner 
from a static 12-item snapshot into a full game plan 
tool. Players can map out their entire game across 
Early/Mid/Late phases, curate a 12-slot Active Build 
grid, flag items for selling or optional use, and 
share the complete plan via a single link.

## Issues closed
- Closes #61 (Plan-06: Share link serialization)
- Closes #60 (Plan-04: Active Items grid)
- Closes #59 (Plan-03: Optional Items category)
- Closes #58 (Plan-01: Game phase structure)
- Closes #51 (Plan-02: Sell Priority category)

## Changes

### Serialization (Plan-06)
- `lib/buildSerializer.ts` — BuildState extended with
  4 compact parallel arrays: phases[], active[], 
  sell[], optional[] — all indexed to itemIds[]
- getItemAssignments() helper zips arrays into
  ItemAssignment[] for component consumption
- Old share links (M3/M4 format) deserialize cleanly
  with safe defaults — no crash on missing fields
- Round-trip assertion in dev mode

### Game phase structure (Plan-01)
- `lib/items.ts` — ItemPhase, ItemAssignment,
  ItemDestination types added
- `app/build/components/CategoryManager.tsx` —
  three fixed phase sections: Early Game (gold),
  Mid Game (blue), Late Game (red)
- Phase sections are DroppableZones — items draggable
  into any phase
- Phase sections collapse/expand, show item count
- Cannot be deleted or renamed

### Active Items grid (Plan-04)
- `app/build/components/ActiveItemsGrid.tsx` — 
  12-slot grid with item icons, soul cost total,
  damage split bar for active items only
- ★ button on each item row toggles active state
- 12-slot cap applies to ACTIVE items only —
  game plan is unlimited
- Header shows "{activeCount}/12 active · 
  {buildItems.length} items"
- 13th active attempt blocked with error toast
- Optional items cannot be marked active

### Sell Priority (Plan-02)
- Sell Priority is a FLAG on items, not a location
- 💰 button on each item row toggles sell priority
- Items with sell priority remain in their phase/category
- Sell Priority section is a filtered view
- Sell refund = 50% of item cost (correct Deadlock rate)
- SELL_REFUND_RATE = 0.5 constant in buildCalculations.ts
- Sell Priority items included in soul calculations
  (player owns them during the game)

### Optional Items (Plan-03)
- Optional is a FLAG on items, not a location
- ? button on each item row toggles optional state
- Optional section is a filtered view
- Optional items EXCLUDED from:
  - calculateDamageSplit()
  - calculateTotalCost()
  - calculateStatTotals()
  - Active Items grid count
- Section tooltip: "Not included in soul calculations"

### Drag and drop fixes
- Within-category reordering restored using arrayMove
- Sell Priority and Optional are NOT drag destinations
- Only phase sections, user categories, and 
  Uncategorized accept drag drops
- ItemDestination type updated to remove sell/optional

## Architecture notes
- Game plan has no item cap — only active build capped
- All new state serialized in share links via parallel arrays
- Sell Priority and Optional are flags, not locations —
  an item can be in Early Game AND marked sell priority
- All calculations are pure and deterministic
- No AI logic anywhere in M5a

## Verification
- `npx tsc --noEmit` — zero errors
- `npx next build` — exit code 0

## Reviewer checklist
- [ ] Add 15+ items to game plan — no slot blocking
- [ ] Drag items into Early/Mid/Late phase sections
- [ ] Within-category drag reorders correctly
- [ ] ★ marks item as active, blocks at 12
- [ ] 💰 flags sell priority, item stays in phase
- [ ] ? flags optional, excluded from calculations
- [ ] Header shows "X/12 active · Y items"
- [ ] Share link round-trip preserves all assignments
- [ ] Old share links load without crash

## Out of scope (M5a — tracked in M5b)
- Plan-05: Soul economy timeline (#52)
- Plan-07: Boon level tracker (#53)
- Plan-08: Ability unlock timeline (#54)
- Plan-09: Hero base stats (#55)
- Plan-10: Ability scaling coefficients (#56)
- Plan-11: Ability detail panel (#57)